### PR TITLE
✨[Feat] 일자리 저장함, 신청함

### DIFF
--- a/src/main/java/com/umc/pyeongsaeng/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/controller/ApplicationController.java
@@ -1,5 +1,7 @@
 package com.umc.pyeongsaeng.domain.application.controller;
 
+import java.util.List;
+
 import com.umc.pyeongsaeng.domain.application.converter.ApplicationConverter;
 import com.umc.pyeongsaeng.domain.application.dto.request.ApplicationRequestDTO;
 import com.umc.pyeongsaeng.domain.application.dto.response.ApplicationResponseDTO;
@@ -7,6 +9,7 @@ import com.umc.pyeongsaeng.domain.application.entity.Application;
 import com.umc.pyeongsaeng.domain.application.service.ApplicationCommandService;
 import com.umc.pyeongsaeng.domain.application.service.ApplicationQueryService;
 import com.umc.pyeongsaeng.global.apiPayload.ApiResponse;
+import com.umc.pyeongsaeng.global.apiPayload.code.status.SuccessStatus;
 import com.umc.pyeongsaeng.global.resolvation.annotation.PageNumber;
 import com.umc.pyeongsaeng.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -262,5 +265,38 @@ public class ApplicationController {
 		@RequestBody @Valid ApplicationRequestDTO.TmpToFinalRegistrationRequestDTO requestDTO) {
 		return ApiResponse.onSuccess(applicationCommandService.updateTmpApplicationToFinalApplication(requestDTO, applicationId, userDetails.getUser()));
 	}
+
+
+	@Operation(summary = "[시니어] 일자리 신청함 - 목록 조회", description = "로그인한 본인의 신청함을 조회합니다. 각 신청서에 해당하는 채용공고는 시니어 채용공고 상세 조회 API를 이용해주세요. NON_STARTED(작성 전), DRAFT(임시저장) 신청서 기준")
+	@GetMapping("/mine")
+	public ApiResponse<List<ApplicationResponseDTO.ApplicationJobPostStatusDTO>> getMyApplications(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.onSuccess(applicationQueryService.getApplicationsForSenior(userDetails.getUser().getId()));
+	}
+
+	@Operation(summary = "[시니어] 일자리 저장함 - 신청 버튼", description = " 추천/상세 화면에서 '신청' 클릭 시 호출합니다. 해당 채용공고에 대한 신청이 없으면 NON_STARTED(작성 전) 상태로 생성합니다. 생성만 하고 끝나며, 목록은 /applications/mine에서 별도 조회하세요.")
+	@PostMapping("/ensure")
+	public ApiResponse<Long> ensureApplication(@Parameter(description = "신청할 채용공고 ID", example = "1") @RequestParam Long jobPostId, @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+		Long applicationId = applicationCommandService.createIfNotExists(jobPostId, userDetails).getId();
+		return ApiResponse.of(SuccessStatus.APPLICATION_NON_STARTED_CREATED, applicationId);
+	}
+
+	@Operation(summary = "[시니어] 일자리 신청함 - 신청 삭제", description = "본인 신청서를 삭제합니다.")
+	@DeleteMapping("/{applicationId}")
+	public ApiResponse<SuccessStatus> deleteApplication( @Parameter(description = "삭제할 신청서 ID", example = "1")@PathVariable Long applicationId, @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+		applicationCommandService.deleteApplication(applicationId, userDetails.getUser().getId());
+		return ApiResponse.onSuccess(SuccessStatus.APPLICATION_DELETED);
+	}
+
+	@Operation(summary = "[보호자] 일자리 신청함 - 연결 시니어 신청함 목록 조회", description = "보호자 계정으로 로그인 시, 연결된 모든 시니어의 신청 목록을 조회합니다. 각 채용공고는 보호자 채용공고 상세조회 API에서 seniorId와 jobPostId를 전달해 호출하세요.")
+	@GetMapping("/protector")
+	public ApiResponse<List<ApplicationResponseDTO.ProtectorApplicationJobPostDTO>> getProtectorApplications(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		Long protectorId = userDetails.getUser().getId();
+		return ApiResponse.onSuccess(applicationQueryService.getProtectorApplications(protectorId));
+	}
+
+
+
 
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/converter/ApplicationConverter.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/converter/ApplicationConverter.java
@@ -123,4 +123,12 @@ public class ApplicationConverter {
 			.answers(answerResultList)
 			.build();
 	}
+
+	public ApplicationResponseDTO.ApplicationJobPostStatusDTO toJobPostStatusDTO(Application application) {
+		return ApplicationResponseDTO.ApplicationJobPostStatusDTO.builder()
+			.applicationId(application.getId())
+			.jobPostId(application.getJobPost().getId())
+			.applicationStatus(application.getApplicationStatus())
+			.build();
+	}
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/dto/response/ApplicationResponseDTO.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/dto/response/ApplicationResponseDTO.java
@@ -10,7 +10,6 @@ import lombok.*;
 
 import java.util.List;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class ApplicationResponseDTO {
@@ -144,5 +143,33 @@ public class ApplicationResponseDTO {
 		private String keyName;
 		private String originalFileName;
 	}
+
+	// 본인(시니어)가 신청함 조회하는 경우 DTO
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class ApplicationJobPostStatusDTO {
+		private Long applicationId;
+		private Long jobPostId;
+		private ApplicationStatus applicationStatus;
+	}
+
+	// 보호자가 연결된 시니어들의 신청함 조회하는 경우 DTO
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class ProtectorApplicationJobPostDTO {
+		private Long applicationId;
+		private Long seniorId;
+		private Long jobPostId;
+		private String seniorName;
+		private ApplicationStatus applicationStatus;
+	}
+
+
+
+
 
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/entity/Application.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/entity/Application.java
@@ -37,6 +37,7 @@ public class Application extends BaseEntity {
 	private User senior;
 
 	@Enumerated(EnumType.STRING)
+	@Column(length = 32)
 	private ApplicationStatus applicationStatus = ApplicationStatus.DRAFT;
 
 	private LocalDateTime submittedAt;

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/enums/ApplicationStatus.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/enums/ApplicationStatus.java
@@ -1,6 +1,7 @@
 package com.umc.pyeongsaeng.domain.application.enums;
 
 public enum ApplicationStatus {
+	NON_STARTED, // 신청함에 있지만 작성 전 상태
 	DRAFT,
 	SUBMITTED,
 	APPROVED,

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/repository/ApplicationRepository.java
@@ -1,5 +1,8 @@
 package com.umc.pyeongsaeng.domain.application.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import com.umc.pyeongsaeng.domain.application.entity.Application;
 import com.umc.pyeongsaeng.domain.application.enums.ApplicationStatus;
 import com.umc.pyeongsaeng.domain.job.entity.JobPost;
@@ -14,4 +17,15 @@ public interface ApplicationRepository extends JpaRepository<Application, Long>,
 
 
 	long countByJobPostId(Long jobPostId);
+
+	// 특정 채용공고에 대한 지원서 조회
+	Optional<Application> findByJobPostIdAndSeniorId(Long jobPostId, Long seniorId);
+
+	// 특정 유저에 대한 모든 채용공고 조회
+	List<Application> findAllBySeniorIdAndApplicationStatusInOrderByUpdatedAtDesc(
+		Long seniorId,
+		List<ApplicationStatus> statuses
+	);
+
+	List<Application> findBySenior_IdInOrderByCreatedAtDesc(List<Long> seniorIds);
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/service/ApplicationCommandService.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/service/ApplicationCommandService.java
@@ -5,6 +5,7 @@ import com.umc.pyeongsaeng.domain.application.dto.request.ApplicationRequestDTO;
 import com.umc.pyeongsaeng.domain.application.dto.response.ApplicationResponseDTO;
 import com.umc.pyeongsaeng.domain.application.entity.Application;
 import com.umc.pyeongsaeng.domain.user.entity.User;
+import com.umc.pyeongsaeng.global.security.CustomUserDetails;
 
 public interface ApplicationCommandService  {
 
@@ -28,5 +29,25 @@ public interface ApplicationCommandService  {
 
 	ApplicationResponseDTO.RegistrationResultDTO updateTmpApplicationToFinalApplication(ApplicationRequestDTO.TmpToFinalRegistrationRequestDTO requestDTO, Long applicationId, User applicant);
 
+	/**
+	 * 특정 채용공고에 대한 "작성 전" 상태의 지원서를 신청함에 저장합니다.
+	 *
+	 * 시니어-채용공고 조합에 이미 지원서가 존재하면 새로 만들지 않고 기존 엔티티를 반환합니다
+	 * 존재하는 경우 클릭한 채용공고가 목록에서 상단에 보이도록 updatedAt을 갱신합니다.
+	 * 최초 생성 시 상태는 NON_STARTED 입니다.
+	 *
+	 * @param jobPostId   신청할 채용공고 ID
+	 * @param userDetails 인증 사용자 정보(시니어)
+	 * @return 생성되었거나(또는 존재하던) Application 엔티티
+	 */
+	Application createIfNotExists(Long jobPostId, CustomUserDetails userDetails);
+
+	/**
+	 * 본인(시니어)가 특정 지원서를 삭제합니다.
+	 *
+	 * @param applicationId 삭제할 지원서 ID
+	 * @param seniorId 시니어 ID
+	 */
+	void deleteApplication(Long applicationId, Long seniorId);
 
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/application/service/ApplicationQueryService.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/application/service/ApplicationQueryService.java
@@ -1,13 +1,41 @@
 package com.umc.pyeongsaeng.domain.application.service;
 
+import java.util.List;
+
 import com.umc.pyeongsaeng.domain.application.dto.response.ApplicationResponseDTO;
 import org.springframework.data.domain.Page;
 
 import com.umc.pyeongsaeng.domain.application.entity.Application;
+import com.umc.pyeongsaeng.domain.application.enums.ApplicationStatus;
 
 public interface ApplicationQueryService {
 
 	Page<Application> findCompanyApplications(Long jobPostId,Integer page);
 
 	ApplicationResponseDTO.ApplicationQnADetailPreViewDTO getApplicationQnADetail(Long applicationId);
+
+	/**
+	 * 특정 시니어(본인)의 신청함 목록을 조회합니다.
+	 *
+	 * 기본적으로 {@code NON_STARTED} (작성 전), {@code DRAFT} (임시저장) 상태의 신청서를 반환합니다.
+	 * 정렬 기준은 {@code updatedAt} 기준으로 최신순 정렬됩니다.
+	 * 각 항목은 채용공고 ID, 신청서 상태, 신청서 ID 등을 포함하며, 채용공고 상세는 별도 API로 조회합니다.
+	 *
+	 * @param seniorId 신청함을 조회할 시니어(본인) 사용자 ID
+	 * @return 신청서 상태와 채용공고 ID를 포함한 DTO 리스트
+	 */
+	List<ApplicationResponseDTO.ApplicationJobPostStatusDTO> getApplicationsForSenior(Long seniorId);
+
+	/**
+	 * 보호자와 연결된 모든 시니어의 신청함 목록을 조회합니다.
+	 *
+	 * 보호자 ID를 기준으로 연결된 모든 시니어의 신청서를 모아 반환합니다.
+	 * 각 항목에는 시니어 이름, 시니어 ID, 채용공고 ID 등 보호자가 확인할 수 있는 최소한의 정보가 포함됩니다.
+	 * 상세 정보(채용공고 내용, 거리 계산 등)는 별도 상세 조회 API를 통해 제공됩니다.
+	 *
+	 * @param protectorId 신청함을 조회할 보호자 사용자 ID
+	 * @return 연결된 시니어들의 신청서 목록 DTO 리스트
+	 */
+	List<ApplicationResponseDTO.ProtectorApplicationJobPostDTO> getProtectorApplications(Long protectorId);
+
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,50 @@
+package com.umc.pyeongsaeng.domain.bookmark.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.BookmarkSummaryListDTO;
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.CreatedBookmarkDTO;
+import com.umc.pyeongsaeng.domain.bookmark.service.BookmarkCommandService;
+import com.umc.pyeongsaeng.domain.bookmark.service.BookmarkQueryService;
+import com.umc.pyeongsaeng.global.apiPayload.ApiResponse;
+import com.umc.pyeongsaeng.global.apiPayload.code.status.SuccessStatus;
+import com.umc.pyeongsaeng.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+	private final BookmarkCommandService bookmarkCommandService;
+	private final BookmarkQueryService bookmarkQueryService;
+
+	// Todo - 이미 북마크한 채용공고 저장 클릭 시 처리 로직 추가 필요
+	@Operation(summary = "[시니어] 추천/상세 페이지- 채용공고 저장 버튼", description = "시니어 본인이 특정 채용공고를 북마크(저장)합니다.")
+	@PostMapping("/{jobPostId}")
+	public ApiResponse<CreatedBookmarkDTO> createBookmark(@PathVariable Long jobPostId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.onSuccess(bookmarkCommandService.createBookmark(jobPostId, userDetails.getId()));
+	}
+
+	@Operation(summary = "[시니어] 일자리 저장함 - 목록 조회", description = "시니어 본인 일자리 저장함(북마크) 목록을 조회합니다.")
+	@GetMapping("/mine")
+	public ApiResponse<BookmarkSummaryListDTO> getBookmarkSummaryList(@AuthenticationPrincipal CustomUserDetails userDetails){
+		return ApiResponse.onSuccess(bookmarkQueryService.getBookmarkSummaryList(userDetails.getId()));
+	}
+
+	@Operation(summary = "[시니어] 일자리 저장함 - 북마크 삭제", description = "일자리 저장함에서 특정 채용공고 북마크를 삭제합니다.")
+	@DeleteMapping("/{jobPostId}")
+	public ApiResponse<SuccessStatus> deleteBookmark(@PathVariable Long jobPostId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		bookmarkCommandService.deleteBookmark(jobPostId, userDetails.getUser().getId());
+		return ApiResponse.onSuccess(SuccessStatus.BOOKMARK_DELETED);
+	}
+
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/converter/BookmarkConverter.java
@@ -1,0 +1,41 @@
+package com.umc.pyeongsaeng.domain.bookmark.converter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.BookmarkSummaryDTO;
+import com.umc.pyeongsaeng.domain.bookmark.entity.Bookmark;
+import com.umc.pyeongsaeng.domain.job.dto.response.JobPostResponseDTO.JobPostDetailDTO;
+import com.umc.pyeongsaeng.domain.job.entity.JobPost;
+import com.umc.pyeongsaeng.domain.job.service.JobPostQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+
+@Component
+@RequiredArgsConstructor
+public class BookmarkConverter {
+
+	private final JobPostQueryService jobPostQueryService;
+
+	public BookmarkSummaryDTO toSummaryDTO(Bookmark bookmark, Long seniorProfileId) {
+		JobPost jobPost = bookmark.getJobPost();
+		Long jobPostId = jobPost.getId();
+
+		JobPostDetailDTO jobPostDetailDTO = jobPostQueryService.getJobPostDetail(jobPostId, seniorProfileId);
+
+		return BookmarkSummaryDTO.builder()
+			.bookmarkId(bookmark.getId())
+			.jobPostDetailDTO(jobPostDetailDTO)
+			.build();
+	}
+
+	public List<BookmarkSummaryDTO> toSummaryDTOList(List<Bookmark> bookmarks, Long seniorProfileId) {
+		return bookmarks.stream()
+			.map(bookmark -> toSummaryDTO(bookmark, seniorProfileId))
+			.toList();
+	}
+
+}
+

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/dto/response/BookmarkResponseDTO.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/dto/response/BookmarkResponseDTO.java
@@ -1,0 +1,47 @@
+package com.umc.pyeongsaeng.domain.bookmark.dto.response;
+
+import java.util.List;
+
+import com.umc.pyeongsaeng.domain.job.dto.response.JobPostResponseDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookmarkResponseDTO {
+
+	/**
+	 * 북마크 생성 후 반환용 DTO
+	 */
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	public static class CreatedBookmarkDTO {
+		private Long bookmarkId;
+	}
+
+	/**
+	 * 북마크 단건 DTO
+	 */
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	public static class BookmarkSummaryDTO {
+		private Long bookmarkId;
+		private JobPostResponseDTO.JobPostDetailDTO jobPostDetailDTO;
+	}
+
+	/**
+	 * 북마크 목록 조회용 DTO
+	 */
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	public static class BookmarkSummaryListDTO {
+		List<BookmarkSummaryDTO> bookmarkSummaryDTOList;
+	}
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/entity/Bookmark.java
@@ -1,0 +1,40 @@
+package com.umc.pyeongsaeng.domain.bookmark.entity;
+
+import com.umc.pyeongsaeng.domain.job.entity.JobPost;
+import com.umc.pyeongsaeng.domain.senior.entity.SeniorProfile;
+import com.umc.pyeongsaeng.global.common.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Bookmark extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="senior_profile_id", nullable = false)
+	private SeniorProfile seniorProfile;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="job_post_id", nullable = false)
+	private JobPost jobPost;
+
+
+
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,17 @@
+package com.umc.pyeongsaeng.domain.bookmark.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO;
+import com.umc.pyeongsaeng.domain.bookmark.entity.Bookmark;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+	List<Bookmark> findAllBySeniorProfile_SeniorId(Long seniorId);
+	Optional<Bookmark> findByJobPostIdAndSeniorProfile_SeniorId(Long jobPostId, Long seniorProfileId);
+
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkCommandService.java
@@ -1,0 +1,9 @@
+package com.umc.pyeongsaeng.domain.bookmark.service;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.CreatedBookmarkDTO;
+
+public interface BookmarkCommandService {
+	CreatedBookmarkDTO createBookmark(Long jobPostId, Long seniorProfileId);
+
+	void deleteBookmark(Long jobPostId, Long seniorProfileId);
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkCommandServiceImpl.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkCommandServiceImpl.java
@@ -1,0 +1,49 @@
+package com.umc.pyeongsaeng.domain.bookmark.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.CreatedBookmarkDTO;
+import com.umc.pyeongsaeng.domain.bookmark.entity.Bookmark;
+import com.umc.pyeongsaeng.domain.bookmark.repository.BookmarkRepository;
+import com.umc.pyeongsaeng.domain.job.entity.JobPost;
+import com.umc.pyeongsaeng.domain.job.repository.JobPostRepository;
+import com.umc.pyeongsaeng.domain.senior.entity.SeniorProfile;
+import com.umc.pyeongsaeng.domain.senior.repository.SeniorProfileRepository;
+import com.umc.pyeongsaeng.global.apiPayload.code.exception.GeneralException;
+import com.umc.pyeongsaeng.global.apiPayload.code.status.ErrorStatus;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkCommandServiceImpl implements BookmarkCommandService {
+	private final BookmarkRepository bookmarkRepository;
+	private final JobPostRepository jobPostRepository;
+	private final SeniorProfileRepository seniorProfileRepository;
+
+	@Override
+	public CreatedBookmarkDTO createBookmark(Long JobPostId, Long seniorProfileId) {
+		JobPost jobPost = jobPostRepository.findById(JobPostId).orElseThrow(()-> new GeneralException(ErrorStatus.INVALID_JOB_POST_ID));
+		SeniorProfile seniorProfile = seniorProfileRepository.findBySeniorId(seniorProfileId).orElseThrow(()->new GeneralException(ErrorStatus.SENIOR_PROFILE_NOT_FOUND));
+
+		Bookmark bookmark = Bookmark.builder().jobPost(jobPost).seniorProfile(seniorProfile).build();
+
+		bookmarkRepository.save(bookmark);
+		return new CreatedBookmarkDTO(bookmark.getId());
+	}
+
+	@Override
+	@Transactional
+	public void deleteBookmark(Long jobPostId, Long seniorProfileId) {
+		Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByJobPostIdAndSeniorProfile_SeniorId(jobPostId, seniorProfileId);
+
+		if (bookmarkOptional.isPresent()) {
+			bookmarkRepository.delete(bookmarkOptional.get());
+		} else {
+			throw new GeneralException(ErrorStatus.BOOKMARK_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkQueryService.java
@@ -1,0 +1,8 @@
+package com.umc.pyeongsaeng.domain.bookmark.service;
+
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.BookmarkSummaryListDTO;
+
+public interface BookmarkQueryService {
+
+	BookmarkSummaryListDTO getBookmarkSummaryList(Long seniorProfileId);
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkQueryServiceImpl.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/bookmark/service/BookmarkQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package com.umc.pyeongsaeng.domain.bookmark.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.umc.pyeongsaeng.domain.bookmark.converter.BookmarkConverter;
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.BookmarkSummaryListDTO;
+import com.umc.pyeongsaeng.domain.bookmark.dto.response.BookmarkResponseDTO.BookmarkSummaryDTO;
+import com.umc.pyeongsaeng.domain.bookmark.entity.Bookmark;
+import com.umc.pyeongsaeng.domain.bookmark.repository.BookmarkRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkQueryServiceImpl implements BookmarkQueryService {
+
+	private final BookmarkRepository bookmarkRepository;
+	private final BookmarkConverter bookmarkConverter;
+
+	@Override
+	public BookmarkSummaryListDTO getBookmarkSummaryList(Long seniorProfileId) {
+		List<Bookmark> bookmarks = bookmarkRepository.findAllBySeniorProfile_SeniorId(seniorProfileId);
+
+		List<BookmarkSummaryDTO> bookmarkSummaryDTOList = bookmarkConverter.toSummaryDTOList(bookmarks, seniorProfileId);
+
+		return BookmarkSummaryListDTO.builder()
+			.bookmarkSummaryDTOList(bookmarkSummaryDTOList)
+			.build();
+	}
+}

--- a/src/main/java/com/umc/pyeongsaeng/domain/job/controller/JobPostController.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/job/controller/JobPostController.java
@@ -479,8 +479,8 @@ public class JobPostController {
 
 		return ApiResponse.onSuccess(jobPostId);
 	}
-  
-	@Operation(summary = "시니어가 채용공고 상세 조회 API", description = "특정 채용공고를 클릭했을 때, 해당 공고의 상세 정보를 조회하는 API입니다.")
+
+	@Operation(summary = "[시니어] - 시니어가 채용공고 상세 조회 API", description = "특정 채용공고를 클릭했을 때, 해당 공고의 상세 정보를 조회하는 API입니다.")
 	@ApiResponses(value = {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 			responseCode = "200",
@@ -552,5 +552,14 @@ public class JobPostController {
 		@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails){
 		return ApiResponse.onSuccess(jobPostQueryService.getJobPostDetail(jobPostId, userDetails.getUser().getId()));
 	}
+
+	@Operation(summary = "[보호자] - 보호자가 특정 시니어 지원 채용공고 상세 조회", description = "보호자가 연결된 시니어의 ID와 채용공고 ID를 기반으로  채용공고 상세 정보를 조회합니다.")
+	@GetMapping("/protector/seniors/{seniorId}/posts/{jobPostId}")
+	public ApiResponse<JobPostResponseDTO.JobPostDetailDTO> getJobPostDetailForProtector(@PathVariable Long seniorId, @PathVariable Long jobPostId) {
+		return ApiResponse.onSuccess(jobPostQueryService.getJobPostDetail(jobPostId, seniorId));
+	}
+
+
+
 
 }

--- a/src/main/java/com/umc/pyeongsaeng/domain/senior/controller/SeniorQuestionController.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/senior/controller/SeniorQuestionController.java
@@ -34,7 +34,14 @@ public class SeniorQuestionController {
 	private final SeniorQuestionQueryService seniorQuestionQueryService;
 	private final SeniorQuestionCommandService seniorQuestionCommandService;
 
-	@Operation(summary = "시니어 추가 질문 전체 조회", description = "해당 시니어 프로필의 모든 추가 질문과 선택 가능한 옵션, 그리고 이미 선택한 답변을 조회합니다.(seniorProfileId = userId)")
+	@Operation(
+		summary = "시니어 추가 질문 전체 조회",
+		description =
+			"해당 시니어 프로필의 모든 추가 질문과 선택 가능한 옵션, 그리고 이미 선택한 답변을 조회합니다.\n" +
+				"- 로그인 유저 - 시니어 본인: seniorProfileId는 현재 로그인한 유저 Id\n" +
+				"- 로그인 유저 - 보호자: 케어 중인 어르신 목록에서 선택한 어르신의 seniorId를 사용"
+	)
+
 	@GetMapping("/{seniorProfileId}/questions")
 	public ApiResponse<List<SeniorQuestionResponseDTO.QuestionAnswerResponseDTO>> getQuestions(@PathVariable Long seniorProfileId) {
 		return ApiResponse.onSuccess(seniorQuestionQueryService.getAllSeniorQuestionsWithAnswers(seniorProfileId));

--- a/src/main/java/com/umc/pyeongsaeng/domain/senior/repository/SeniorProfileRepository.java
+++ b/src/main/java/com/umc/pyeongsaeng/domain/senior/repository/SeniorProfileRepository.java
@@ -17,4 +17,6 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
 	Optional<SeniorProfile> findBySeniorId(Long seniorId);
 	List<SeniorProfile> findByProtectorId(Long protectorId);
 	boolean existsBySeniorIdAndProtectorId(Long seniorId, Long protectorId);
+
+	List<SeniorProfile> findByProtector_Id(Long protectorId);
 }

--- a/src/main/java/com/umc/pyeongsaeng/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/pyeongsaeng/global/apiPayload/code/status/ErrorStatus.java
@@ -87,6 +87,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	// Application
 	INVALID_APPLICATION_ID(HttpStatus.BAD_REQUEST, "APPLICATION400", "유효하지 않은 ApplicationId 입니다."),
 	APPLICATION_PARSING_ERROR(HttpStatus.BAD_REQUEST, "APPLICATION500", "결과 파싱에러 입니다. 관리자에게 문의해주세요"),
+	DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATION401","임시저장한 Application이 존재하지 않습니다."),
 
 	// FormField
 	FORM_FIELD_NOT_FOUND(HttpStatus.BAD_REQUEST, "FORMFIELD400", "유효하지 않은 formFieldId 입니다"),
@@ -100,7 +101,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	// AI
 	AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI501", "AI 응답 파싱에 실패했습니다."),
-	AI_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI502", "AI 요청 중 오류가 발생했습니다.");
+	AI_REQUEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI502", "AI 요청 중 오류가 발생했습니다."),
+
+	// Bookmark
+	BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK401", "일자리 저장함에 해당 채용공고가 존재하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/umc/pyeongsaeng/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/pyeongsaeng/global/apiPayload/code/status/SuccessStatus.java
@@ -32,7 +32,14 @@ public enum SuccessStatus implements BaseCode {
 
 	// Question
 	SENIOR_QUESTION_CREATED(HttpStatus.OK, "QUESTION201", "질문이 생성되었습니다."),
-	SENIOR_QUESTION_ANSWER_SELECTED(HttpStatus.OK, "QUESTION202", "추가 질문 답변이 새로 저장되었습니다.");
+	SENIOR_QUESTION_ANSWER_SELECTED(HttpStatus.OK, "QUESTION202", "추가 질문 답변이 새로 저장되었습니다."),
+
+	// Application
+	APPLICATION_NON_STARTED_CREATED(HttpStatus.OK, "APPLICATION201", "일자리 신청함에 저장되었습니다."),
+	APPLICATION_DELETED(HttpStatus.OK,"APPLICATION202", "일자리 신청함에서 지원서가 삭제되었습니다."),
+
+	// Bookmark
+	BOOKMARK_DELETED(HttpStatus.OK,"Bookmark201", "일자리 저장함에서 채용공고 북마크가 삭제되었습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #68 

어떤 변경사항이 있었나요?
- [ ] 🐛 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [x] 📃 Docs Documentation writing and editing (README.md, Swagger, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related 

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다.
- [x] commit convention을 지켰습니다.
- [x] Issue를 생성하고, Issue 번호에 맞는 브랜치를 생성했습니다.
- [x] Issue 컨벤션에 맞게 Issue를 생성했습니다.

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- [x] 일자리 신청함, 저장함 기능 구현
- [x] 채용공고 상세조회 API 추가 (보호자 전용)
- [x] 시니어/보호자에 따른 일자리 신청함 목록 조회 API

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
없다면 N/A를 작성해주세요.
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
작성 전이지만 신청함에 지원서가 존재하는 경우를 구분하기 위해 NON_STARTED 상태를 추가했고, 신청함 목록에는 작성 전(NON_STARTED)과 임시 저장(DRAFT) 상태의 지원서만 노출되도록 처리했습니다.
또한 저장함은 PM님과 상의한 결과, 북마크같은 기능으로 사용자가 북마크한 일자리 목록을 모두 볼 수 있도록 하는 기능임을 확인하여 이에따라 구현했습니다.